### PR TITLE
feat: use new HTTP API to send queries to the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ Install this package using your package manager and registry of choice:
 
 ## Usage
 
-The recommended API for most users is the `createClient` function, which returns
+The recommended API for most users is the `ppg` function, which returns
 a high-level SQL client implemented as a template literal tag function:
 
 ```ts
-import { createClient } from "@prisma/ppg";
+import { ppg } from "@prisma/ppg";
 
-const sql = createClient("prisma+postgres://accelerate.prisma-data.net/?api_key=...");
-const user = await sql`SELECT * FROM users WHERE id = ${id}`;
+const sql = ppg("prisma+postgres://accelerate.prisma-data.net/?api_key=...");
+
+const userId = 1;
+const posts = await sql`SELECT * FROM posts WHERE user_id = ${userId}`;
 ```
 
 The interpolated values are automatically converted to SQL parameters to
@@ -37,8 +39,12 @@ const client = new Client({
   connectionString: "prisma+postgres://accelerate.prisma-data.net/?api_key=...",
 });
 
-const user = await client.query("SELECT * FROM users WHERE id = $1", [id]);
+const posts = await client.query("SELECT * FROM posts WHERE user_id = $1", [1]);
 ```
+
+## Limitations
+
+Transactions are not currently supported.
 
 ## License
 

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,8 @@
         "useImportExtensions": "error"
       },
       "style": {
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "off",
+        "useShorthandFunctionType": "off"
       }
     }
   },

--- a/example.ts
+++ b/example.ts
@@ -1,6 +1,21 @@
-import { createClient } from "./src/index.ts";
+import ppg from "./src/index.ts";
 
-const sql = createClient(process.env.E2E_PPG_URL!);
+const sql = ppg(process.env.E2E_PPG_URL!);
 
-const text = "hello";
-console.log(await sql`select ${text} as t`);
+await sql`create table if not exists users (
+  id uuid primary key default gen_random_uuid(),
+  email text not null unique,
+  name text not null
+)`;
+
+await sql`insert into users (email, name) values ('test@example.com', 'Test User') on conflict do nothing`;
+
+type User = {
+  id: string;
+  email: string;
+  name: string;
+};
+
+const users: User[] = await sql`select * from users`;
+
+console.log(users);

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/ppg",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "exports": "./src/index.ts",
   "publish": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@prisma/ppg",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Lightweight client for Prisma Postgres",
-  "keywords": ["prisma", "postgres", "ppg", "database", "client", "sql"],
+  "keywords": [
+    "prisma",
+    "postgres",
+    "postgresql",
+    "ppg",
+    "database",
+    "client",
+    "sql",
+    "serverless"
+  ],
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -13,7 +22,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --target esnext --out-dir dist",
-    "format": "biome format --write",
+    "format": "biome check --write",
     "prepack": "pnpm build"
   },
   "files": ["dist"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,39 @@
 import { Client } from "./client.ts";
-import { type Sql, sqlFactory } from "./sql.ts";
+import { type Deserialize, type Sql, sqlFactory } from "./sql.ts";
 
+export {
+  Client,
+  type ClientOptions,
+  RequestError,
+  SqlError,
+} from "./client.ts";
+export type { Column, QueryResponse } from "./queryable.ts";
 export { ConnectionStringError } from "./url.ts";
-export { Client, RequestError } from "./client.ts";
+export type { Deserialize, Sql } from "./sql.ts";
 
 /**
  * Connects to the specified Prisma Postgres database and returns a high-level
  * SQL client provided as a template literal tag function.
  *
  * ```ts
- * const sql = createClient("prisma+postgres://accelerate.prisma-data.net/?api_key=...");
- * const user = await sql`SELECT * FROM users WHERE id = ${id}`;
+ * const sql = ppg("prisma+postgres://accelerate.prisma-data.net/?api_key=...");
+ * const posts: Post[] = await sql`SELECT * FROM posts WHERE user_id = ${userId}`;
  * ```
  *
  * The interpolated values are automatically converted to SQL parameters to
  * prevent SQL injection attacks.
  *
+ * You can also pass a custom deserializer function to convert the values based
+ * on the column type.
+ *
  * See also {@link Client} for the low-level client API.
  */
-export function createClient(url: string): Sql {
+export function ppg(
+  url: string,
+  deserialize: Deserialize = (value) => value,
+): Sql {
   const client = new Client({ connectionString: url });
-  return sqlFactory(client);
+  return sqlFactory(client, deserialize);
 }
+
+export default ppg;

--- a/src/queryable.ts
+++ b/src/queryable.ts
@@ -1,0 +1,44 @@
+/**
+ * Result of the database query.
+ */
+export interface QueryResponse {
+  /**
+   * Column definitions.
+   */
+  columns: Column[];
+
+  /**
+   * Array of rows, where each row is an array of values with their indices
+   * corresponding to the indices of the column definitions.
+   */
+  rows: unknown[][];
+}
+
+/**
+ * Column definition.
+ */
+export interface Column {
+  /**
+   * Name of the column.
+   */
+  name: string;
+
+  /**
+   * Object identifier of the column type.
+   *
+   * If you need to know the column type name, you can use the `oid` to query
+   * the `pg_type` catalog:
+   *
+   * ```ts
+   * await client.query(
+   *   `SELECT typname FROM pg_type WHERE oid = $1`,
+   *   [column.oid]
+   * );
+   * ```
+   */
+  oid: number;
+}
+
+export interface Queryable {
+  query(query: string, parameters: unknown[]): Promise<QueryResponse>;
+}

--- a/src/url.ts
+++ b/src/url.ts
@@ -6,7 +6,6 @@ export class ConnectionStringError extends Error {
 }
 
 export interface ConnectionString {
-  baseUrl: URL;
   apiKey: string;
 }
 
@@ -27,13 +26,10 @@ export function parsePpgConnectionString(
   let baseUrl: URL;
 
   if (isLocalhost(url.hostname)) {
-    baseUrl = new URL(`http://${url.host}`);
-  } else {
-    baseUrl = new URL(`https://${url.host}`);
+    throw new ConnectionStringError("Local Prisma Postgres is not supported");
   }
 
   return {
-    baseUrl,
     apiKey,
   };
 }


### PR DESCRIPTION
Use the new HTTP API to send queries directly to the database without having to spin up a query engine. This allows sending any SQL query, including DDL.

### Breaking changes

`createClient` function was renamed to `ppg`, for consistency with other similar drivers that have an equivalent function:

* Neon serverless driver calls it `neon`
* Postgres.js calls it `postgres`

The old name was confusing, as it didn't actually return a `Client` instance.

---

Closes: https://linear.app/prisma-company/issue/ORM-981/implement-ddl-statements-support