### PR TITLE
feat: add `sql.query` function 

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert/strict";
+
 import ppg from "./src/index.ts";
 
 const sql = ppg(process.env.E2E_PPG_URL!);
@@ -19,3 +21,12 @@ type User = {
 const users: User[] = await sql`select * from users`;
 
 console.log(users);
+
+const [user1] =
+  await sql<User>`select * from users where email = ${"test@example.com"}`;
+
+const [user2] = await sql.query<User>("select * from users where email = $1", [
+  "test@example.com",
+]);
+
+assert.equal(user1.id, user2.id);

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/ppg",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "license": "Apache-2.0",
   "exports": "./src/index.ts",
   "publish": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/ppg",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "Lightweight client for Prisma Postgres",
   "keywords": [
     "prisma",

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,7 +32,7 @@ interface PostgresError {
   severity_local: string;
   severity: string;
   code: string;
-  position: string;
+  position?: string;
   file: string;
   line: string;
   routine: string;
@@ -46,7 +46,7 @@ export class SqlError extends RequestError {
   severityLocal: string;
   severity: string;
   code: string;
-  position: string;
+  position?: string;
   file: string;
   line: string;
   routine: string;
@@ -120,7 +120,6 @@ export class Client implements Queryable {
       "severity_local" in errorJson &&
       "severity" in errorJson &&
       "code" in errorJson &&
-      "position" in errorJson &&
       "file" in errorJson &&
       "line" in errorJson &&
       "routine" in errorJson


### PR DESCRIPTION
Add `sql.query` function, similar to the Neon driver.

The difference from the `sql` template literal is that the user is expected to provide a raw query with placeholders and a separate array of values.

The difference from `Client#query`, which accepts the same arguments, is that `sql.query` returns deserialized results as an array of objects and not the raw response.