### PR TITLE
fix: make sql.query type definition consistent with implementation

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/ppg",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "exports": "./src/index.ts",
   "publish": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/ppg",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Lightweight client for Prisma Postgres",
   "keywords": [
     "prisma",

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -21,7 +21,7 @@ export interface Sql {
    * const [user] = await sql.query<User>("SELECT * FROM users WHERE id = $1", [id]);
    * ```
    */
-  query<Record>(query: string, ...params: unknown[]): Promise<Record[]>;
+  query<Record>(query: string, params: unknown[]): Promise<Record[]>;
 }
 
 export type Deserialize = (value: unknown, oid: unknown) => unknown;


### PR DESCRIPTION
Fix incorrect `sql.query` type definition.